### PR TITLE
Upgrade dependencies to support ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04, macos-latest, windows-latest]
         python-version: ["3.11", "3.10", "3.9"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI - Test Install Requirements
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
+        python-version: [3.10, 3.9, 3.8]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
-        python-version: [3.11, 3.10, 3.9, 3.8]
+        python-version: ["3.11", "3.10", "3.9"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
-        python-version: [3.10, 3.9, 3.8]
+        python-version: [3.11, 3.10, 3.9, 3.8]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ as seen. Optionally downloads comics to ./comics/
 ## Dependencies ##
 
 * python3
-* MacOS or Linux (not tested on Windows)
-* see contents of requirements.txt
+* MacOS or Ubuntu (tested on 20.04-24.04)
 
 ## Limitations ##
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-certifi==2023.11.17
+certifi==2024.7.4
 charset-normalizer==3.3.2
-idna==3.6
-python-dotenv==1.0.0
+idna==3.7
+python-dotenv==1.0.1
 python-http-client==3.3.7
-requests==2.31.0
-sendgrid==6.10.0
+requests==2.32.3
+sendgrid==6.11.0
 starkbank-ecdsa==2.2.0
-urllib3==2.1.0
+urllib3==2.2.2


### PR DESCRIPTION
This PR:

* upgrades all dependencies
* adds support for Ubuntu 24.04
* removes support for Ubuntu 18.04
* adds a CI test to verify pip install works on all supported OS and python versions